### PR TITLE
Feat: add diversity@K metric

### DIFF
--- a/sojong-exp/Procedure.py
+++ b/sojong-exp/Procedure.py
@@ -105,7 +105,8 @@ def Test(dataset, Recmodel, epoch, w=None, multicore=0):
     
     results = {'precision': np.zeros(len(world.topks)),
                'recall': np.zeros(len(world.topks)),
-               'ndcg': np.zeros(len(world.topks))}
+               'ndcg': np.zeros(len(world.topks)),
+               'diversity': 0}
     with torch.no_grad():
         users = list(testDict.keys())
         try:
@@ -165,6 +166,7 @@ def Test(dataset, Recmodel, epoch, w=None, multicore=0):
         results['recall'] /= float(len(users))
         results['precision'] /= float(len(users))
         results['ndcg'] /= float(len(users))
+        results['diversity'] = utils.get_diversity(dataset.m_items, rating_list)
         # results['auc'] = np.mean(auc_record)
         if world.tensorboard:
             w.add_scalars(f'Test/Recall@{world.topks}',
@@ -211,7 +213,8 @@ def Test_exp1(dataset, epoch, w=None, multicore=0):
         start_time = time()
         results = {'precision': np.zeros(len(world.topks)),
                 'recall': np.zeros(len(world.topks)),
-                'ndcg': np.zeros(len(world.topks))}
+                'ndcg': np.zeros(len(world.topks)),
+                'diversity': 0}
         with torch.no_grad():
             users = list(testDict.keys())
             try:
@@ -271,6 +274,7 @@ def Test_exp1(dataset, epoch, w=None, multicore=0):
             results['recall'] /= float(len(users))
             results['precision'] /= float(len(users))
             results['ndcg'] /= float(len(users))
+            results['diversity'] = utils.get_diversity(dataset.m_items, rating_list)
             # results['auc'] = np.mean(auc_record)
             if world.tensorboard:
                 w.add_scalars(f'Test/Recall@{world.topks}',
@@ -313,7 +317,8 @@ def Test_exp2(dataset, epoch, w=None, multicore=0):
     start_time = time()
     results = {'precision': np.zeros(len(world.topks)),
             'recall': np.zeros(len(world.topks)),
-            'ndcg': np.zeros(len(world.topks))}
+            'ndcg': np.zeros(len(world.topks)),
+            'diversity': 0}
     with torch.no_grad():
         users = list(testDict.keys())
         try:
@@ -373,6 +378,7 @@ def Test_exp2(dataset, epoch, w=None, multicore=0):
         results['recall'] /= float(len(users))
         results['precision'] /= float(len(users))
         results['ndcg'] /= float(len(users))
+        results['diversity'] = utils.get_diversity(dataset.m_items, rating_list)
         # results['auc'] = np.mean(auc_record)
         if world.tensorboard:
             w.add_scalars(f'Test/Recall@{world.topks}',

--- a/sojong-exp/utils.py
+++ b/sojong-exp/utils.py
@@ -277,5 +277,17 @@ def getLabel(test_data, pred_data):
         r.append(pred)
     return np.array(r).astype('float')
 
+def get_diversity(m_items, rating_list):
+    
+    item_list = []
+            
+    for batch in rating_list:
+        batch = batch.numpy()
+        for user in batch:
+            for item in user:
+                item_list.append(item)
+        
+    return len(set(item_list)) / m_items
+
 # ====================end Metrics=============================
 # =========================================================


### PR DESCRIPTION
## PR 제목
다양성 지표 추가

### PR 생성일시
* 2023/05/04

### PR 내용
precision, recall, ndcg에 이어서 diversity 지표 추가.
다양성(diversity) 지표는 전체 아이템 중, 추천에 사용되는 아이템의 비율을 나타낸 것으로서
다양한 아이템이 추천 될수록 개인 맞춤 추천이 잘 진행되며 모델이 견고하고 성능이 높은 것으로 평가할 수 있음

### PR 유의사항