### PR TITLE
[CONTAIN DOCUMENT FOR exp1,2,3] Add cupyx, changed filter.py, parser structure, changed parser option.

### DIFF
--- a/sojong-exp/Procedure.py
+++ b/sojong-exp/Procedure.py
@@ -442,26 +442,30 @@ def Test_exp2(dataset, epoch, w=None, multicore=0):
             w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Recall", world.topks[i]), 
                     {   str(world.config['svdtype']) + "_" + 
                         str(world.config['svdvalue']) + "_" + 
-                        str(world.config['filter']) + "_" + 
-                        str(world.config['filter_option']) : 
+                        # str(world.config['filter']) + "_" + 
+                        # str(world.config['filter_option']) :
+                        str(world.config['filter']) : 
                         results['recall'][i]}, world.dataset_step[world.dataset])
             w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Precision", world.topks[i]), 
                     {   str(world.config['svdtype']) + "_" + 
                         str(world.config['svdvalue']) + "_" + 
-                        str(world.config['filter']) + "_" + 
-                        str(world.config['filter_option']) : 
+                        # str(world.config['filter']) + "_" + 
+                        # str(world.config['filter_option']) :
+                        str(world.config['filter']) :  
                         results['precision'][i]}, world.dataset_step[world.dataset])
             w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "NDCG", world.topks[i]), 
                     {   str(world.config['svdtype']) + "_" + 
                         str(world.config['svdvalue']) + "_" + 
-                        str(world.config['filter']) + "_" + 
-                        str(world.config['filter_option']) : 
+                        # str(world.config['filter']) + "_" + 
+                        # str(world.config['filter_option']) : 
+                        str(world.config['filter']) : 
                         results['ndcg'][i]}, world.dataset_step[world.dataset])
             w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Diversity", world.topks[i]), 
                     {   str(world.config['svdtype']) + "_" + 
                         str(world.config['svdvalue']) + "_" + 
-                        str(world.config['filter']) + "_" + 
-                        str(world.config['filter_option']) : 
+                        # str(world.config['filter']) + "_" + 
+                        # str(world.config['filter_option']) :
+                        str(world.config['filter']) :  
                         results['diversity'][i]}, world.dataset_step[world.dataset])
     if multicore == 1:
         pool.close()
@@ -576,28 +580,28 @@ def Test_exp3(dataset, epoch, w=None, multicore=0):
                         {   str(world.config['svdtype']) + "_" + 
                             str(world.config['svdvalue']) + "_" + 
                             str(world.config['filter']) + "_" + 
-                            str(world.config['filter_option']) + "_" +
+                            # str(world.config['filter_option']) + "_" +
                             str(alpha) : 
                             results['recall'][i]}, world.dataset_step[world.dataset])
                 w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Precision", world.topks[i]), 
                         {   str(world.config['svdtype']) + "_" + 
                             str(world.config['svdvalue']) + "_" + 
                             str(world.config['filter']) + "_" + 
-                            str(world.config['filter_option']) + "_" +
+                            # str(world.config['filter_option']) + "_" +
                             str(alpha) : 
                             results['precision'][i]}, world.dataset_step[world.dataset])
                 w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "NDCG", world.topks[i]), 
                         {   str(world.config['svdtype']) + "_" + 
                             str(world.config['svdvalue']) + "_" + 
                             str(world.config['filter']) + "_" + 
-                            str(world.config['filter_option']) + "_" +
+                            # str(world.config['filter_option']) + "_" +
                             str(alpha) : 
                             results['ndcg'][i]}, world.dataset_step[world.dataset])
                 w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Diversity", world.topks[i]), 
                         {   str(world.config['svdtype']) + "_" + 
                             str(world.config['svdvalue']) + "_" + 
                             str(world.config['filter']) + "_" + 
-                            str(world.config['filter_option']) + "_" +
+                            # str(world.config['filter_option']) + "_" +
                             str(alpha) : 
                             results['diversity'][i]}, world.dataset_step[world.dataset])
         if multicore == 1:

--- a/sojong-exp/Procedure.py
+++ b/sojong-exp/Procedure.py
@@ -62,15 +62,31 @@ def test_one_batch(X):
     sorted_items = X[0].numpy()
     groundTrue = X[1]
     r = utils.getLabel(groundTrue, sorted_items)
+    # pre, recall, ndcg = [], [], []
     pre, recall, ndcg = [], [], []
+    item_dict = dict()
+
     for k in world.topks:
         ret = utils.RecallPrecision_ATk(groundTrue, r, k)
         pre.append(ret['precision'])
         recall.append(ret['recall'])
         ndcg.append(utils.NDCGatK_r(groundTrue,r,k))
+        item_dict[k] = []
+    for user in sorted_items:
+        for i, item in enumerate(user):
+            [item_dict[key].append(item) for key in item_dict.keys() if i <= key]
+            # for key in item_dict.keys():
+            #     # print(i, key)
+            #     if i <= key:
+            #         item_dict[key].append(item)
+    # return {'recall':np.array(recall), 
+    #         'precision':np.array(pre), 
+    #         'ndcg':np.array(ndcg)}
+    diversity_return = [list(set(value)) for value in item_dict.values()]
     return {'recall':np.array(recall), 
-            'precision':np.array(pre), 
-            'ndcg':np.array(ndcg)}
+        'precision':np.array(pre), 
+        'ndcg':np.array(ndcg), 
+        'diversity':diversity_return} # shape = (#topks, #batch)
         
 
 def Test(dataset, Recmodel, epoch, w=None, multicore=0):
@@ -102,9 +118,10 @@ def Test(dataset, Recmodel, epoch, w=None, multicore=0):
     # print(f"Core: {CORES} current process: {c_proc.name} and PID:{c_proc.pid}")
     
     results = {'precision': np.zeros(len(world.topks)),
-               'recall': np.zeros(len(world.topks)),
-               'ndcg': np.zeros(len(world.topks)),
-               'diversity': 0}
+        'recall': np.zeros(len(world.topks)),
+        'ndcg': np.zeros(len(world.topks)),
+        'diversity': [[] for _ in range(len(world.topks))]}
+
     with torch.no_grad():
         users = list(testDict.keys())
         try:
@@ -161,10 +178,14 @@ def Test(dataset, Recmodel, epoch, w=None, multicore=0):
             results['recall'] += result['recall']
             results['precision'] += result['precision']
             results['ndcg'] += result['ndcg']
+            for i in range(len(world.topks)):
+                results['diversity'][i] += result['diversity'][i]
         results['recall'] /= float(len(users))
         results['precision'] /= float(len(users))
         results['ndcg'] /= float(len(users))
-        results['diversity'] = utils.get_diversity(dataset.m_items, rating_list)
+        for i in range(len(world.topks)):
+            results['diversity'][i] = len(list(set(results['diversity'][i]))) / dataset.m_items
+        results['diversity'] = np.array(results['diversity'])
         # results['auc'] = np.mean(auc_record)
         if world.tensorboard:
             w.add_scalars(f'Test/Recall@{world.topks}',
@@ -173,12 +194,26 @@ def Test(dataset, Recmodel, epoch, w=None, multicore=0):
                           {str(world.topks[i]): results['precision'][i] for i in range(len(world.topks))}, epoch)
             w.add_scalars(f'Test/NDCG@{world.topks}',
                           {str(world.topks[i]): results['ndcg'][i] for i in range(len(world.topks))}, epoch)
+            # add diversity
+            # w.add_scalars(f'Test/diversity@{world.topks}',
+            #             {str(world.topks[i]): results['diversity'] for i in range(len(world.topks))}, epoch)
         if multicore == 1:
             pool.close()
             pool.join()
         print(results)
         return results
 
+def tensorboard_folder_name(exp_num, dataset, score_type, topk) -> str :
+    """
+    we don't use dataset - 
+    step 0 is amazon-book
+    step 1 is gowalla
+    step 2 is yelp2018
+    step 3 is lastfm
+    """
+    # return str(exp_num) + "-" + str(dataset) + "/" + str(score_type) + "@" + str(topk)
+    return str(exp_num) + "/" + str(score_type) + "@" + str(topk)
+    
 def Test_exp1(dataset, epoch, w=None, multicore=0):
     u_batch_size = world.config['test_u_batch_size']
     dataset: utils.BasicDataset
@@ -212,7 +247,263 @@ def Test_exp1(dataset, epoch, w=None, multicore=0):
         results = {'precision': np.zeros(len(world.topks)),
                 'recall': np.zeros(len(world.topks)),
                 'ndcg': np.zeros(len(world.topks)),
-                'diversity': 0}
+                'diversity': [[] for _ in range(len(world.topks))]}
+        
+        users = list(testDict.keys())
+        try:
+            assert u_batch_size <= len(users) / 10
+        except AssertionError:
+            print(f"test_u_batch_size is too big for this dataset, try a small one {len(users) // 10}")
+        users_list = []
+        rating_list = []
+        groundTrue_list = []
+        # auc_record = []
+        # ratings = []
+        total_batch = len(users) // u_batch_size + 1
+
+        for batch_users in utils.minibatch(users, batch_size=u_batch_size):
+            allPos = dataset.getUserPosItems(batch_users)
+            groundTrue = [testDict[u] for u in batch_users]
+            if world.config['expdevice'][:4] != 'cpu':
+                batch_ratings = adj_mat[batch_users, :].to(world.config['expdevice'])
+                rating = lm.getUsersRating(alpha, batch_ratings=batch_ratings, batch_users=batch_users)
+            else:
+                rating = lm.getUsersRating(alpha, batch_users=batch_users)
+                rating = torch.from_numpy(rating)
+            # rating = rating.to(world.device)
+
+            #rating = rating.cpu()
+            exclude_index = []
+            exclude_items = []
+            for range_i, items in enumerate(allPos):
+                exclude_index.extend([range_i] * len(items))
+                exclude_items.extend(items)
+            rating[exclude_index, exclude_items] = -(1<<10)
+            _, rating_K = torch.topk(rating, k=max_K)
+            rating = rating.cpu().numpy()
+            # aucs = [ 
+            #         utils.AUC(rating[i],
+            #                   dataset, 
+            #                   test_data) for i, test_data in enumerate(groundTrue)
+            #     ]
+            # auc_record.extend(aucs)
+            del rating
+            users_list.append(batch_users)
+            rating_list.append(rating_K.cpu())
+            groundTrue_list.append(groundTrue)
+        assert total_batch == len(users_list)
+        X = zip(rating_list, groundTrue_list)
+        if multicore == 1:
+            pre_results = pool.map(test_one_batch, X)
+        else:
+            pre_results = []
+            for x in X:
+                pre_results.append(test_one_batch(x))
+        scale = float(u_batch_size/len(users))
+        for result in pre_results:
+            results['recall'] += result['recall']
+            results['precision'] += result['precision']
+            results['ndcg'] += result['ndcg']
+            for i in range(len(world.topks)):
+                results['diversity'][i] += result['diversity'][i]
+        results['recall'] /= float(len(users))
+        results['precision'] /= float(len(users))
+        results['ndcg'] /= float(len(users))
+        for i in range(len(world.topks)):
+            results['diversity'][i] = len(list(set(results['diversity'][i]))) / dataset.m_items
+        results['diversity'] = np.array(results['diversity'])
+        # results['auc'] = np.mean(auc_record)
+        if world.tensorboard:
+            for i in range(len(world.topks)):
+                w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Recall", world.topks[i]), 
+                        {   str(world.config['svdtype']) + "_" + 
+                            str(world.config['svdvalue']) + "_" + 
+                            str(alpha) :
+                            results['recall'][i]}, world.dataset_step[world.dataset])
+                w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Precision", world.topks[i]), 
+                        {   str(world.config['svdtype']) + "_" + 
+                            str(world.config['svdvalue']) + "_" + 
+                            str(alpha) :
+                            results['precision'][i]}, world.dataset_step[world.dataset])
+                w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "NDCG", world.topks[i]), 
+                        {   str(world.config['svdtype']) + "_" + 
+                            str(world.config['svdvalue']) + "_" + 
+                            str(alpha) :
+                            results['ndcg'][i]}, world.dataset_step[world.dataset])
+                w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Diversity", world.topks[i]), 
+                        {   str(world.config['svdtype']) + "_" + 
+                            str(world.config['svdvalue']) + "_" + 
+                            str(alpha) : 
+                            results['diversity'][i]}, world.dataset_step[world.dataset])
+        if multicore == 1:
+            pool.close()
+            pool.join()
+        world.cprint(f"alpha: {alpha}")
+        print(results)
+        end_time = time()
+        print(f"time consumption: {end_time-start_time}s")
+
+
+def Test_exp2(dataset, epoch, w=None, multicore=0):
+    u_batch_size = world.config['test_u_batch_size']
+    dataset: utils.BasicDataset
+    testDict: dict = dataset.testDict
+    adj_mat = dataset.UserItemNet.tolil()
+    if world.simple_model != 'exp2':
+        raise NotImplementedError
+    
+    lm = model.EXP2(adj_mat)
+    lm.train()
+
+    # eval mode with no dropout
+    max_K = max(world.topks)
+    # Current Problem: Only use Multiprocessing at concating all results, not procedure part
+    # So need to change this part
+    if multicore == 1:
+        pool = multiprocessing.Pool(CORES)
+    #     c_proc = multiprocessing.current_process()
+    # print(f"Core: {CORES} current process: {c_proc.name} and PID:{c_proc.pid}")
+
+    if world.config['expdevice'][:4] != 'cpu':
+        adj_mat = convert_sp_mat_to_sp_tensor(adj_mat).to_dense()
+
+    start_time = time()
+    results = {'precision': np.zeros(len(world.topks)),
+            'recall': np.zeros(len(world.topks)),
+            'ndcg': np.zeros(len(world.topks)),
+            'diversity': [[] for _ in range(len(world.topks))]}
+    users = list(testDict.keys())
+    try:
+        assert u_batch_size <= len(users) / 10
+    except AssertionError:
+        print(f"test_u_batch_size is too big for this dataset, try a small one {len(users) // 10}")
+    users_list = []
+    rating_list = []
+    groundTrue_list = []
+    # auc_record = []
+    # ratings = []
+    total_batch = len(users) // u_batch_size + 1
+    
+    for batch_users in utils.minibatch(users, batch_size=u_batch_size):
+        allPos = dataset.getUserPosItems(batch_users)
+        groundTrue = [testDict[u] for u in batch_users]
+        if world.config['expdevice'][:4] != 'cpu':
+            batch_ratings = adj_mat[batch_users, :].to(world.config['expdevice'])
+            rating = lm.getUsersRating(batch_ratings=batch_ratings, batch_users=batch_users)
+        else:
+            rating = lm.getUsersRating(batch_users=batch_users)
+            rating = torch.from_numpy(rating)
+        # rating = rating.to(world.device)
+
+        #rating = rating.cpu()
+        exclude_index = []
+        exclude_items = []
+        for range_i, items in enumerate(allPos):
+            exclude_index.extend([range_i] * len(items))
+            exclude_items.extend(items)
+        rating[exclude_index, exclude_items] = -(1<<10)
+        _, rating_K = torch.topk(rating, k=max_K)
+        rating = rating.cpu().numpy()
+        # aucs = [ 
+        #         utils.AUC(rating[i],
+        #                   dataset, 
+        #                   test_data) for i, test_data in enumerate(groundTrue)
+        #     ]
+        # auc_record.extend(aucs)
+        del rating
+        users_list.append(batch_users)
+        rating_list.append(rating_K.cpu())
+        groundTrue_list.append(groundTrue)
+    assert total_batch == len(users_list)
+    X = zip(rating_list, groundTrue_list)
+    if multicore == 1:
+        pre_results = pool.map(test_one_batch, X)
+    else:
+        pre_results = []
+        for x in X:
+            pre_results.append(test_one_batch(x))
+    scale = float(u_batch_size/len(users))
+    for result in pre_results:
+        results['recall'] += result['recall']
+        results['precision'] += result['precision']
+        results['ndcg'] += result['ndcg']
+        for i in range(len(world.topks)):
+            results['diversity'][i] += result['diversity'][i]
+    results['recall'] /= float(len(users))
+    results['precision'] /= float(len(users))
+    results['ndcg'] /= float(len(users))
+    for i in range(len(world.topks)):
+        results['diversity'][i] = len(list(set(results['diversity'][i]))) / dataset.m_items
+    results['diversity'] = np.array(results['diversity'])
+    # results['auc'] = np.mean(auc_record)
+    
+    if world.tensorboard:
+        for i in range(len(world.topks)):
+            w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Recall", world.topks[i]), 
+                    {   str(world.config['svdtype']) + "_" + 
+                        str(world.config['svdvalue']) + "_" + 
+                        str(world.config['filter']) + "_" + 
+                        str(world.config['filter_option']) : 
+                        results['recall'][i]}, world.dataset_step[world.dataset])
+            w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Precision", world.topks[i]), 
+                    {   str(world.config['svdtype']) + "_" + 
+                        str(world.config['svdvalue']) + "_" + 
+                        str(world.config['filter']) + "_" + 
+                        str(world.config['filter_option']) : 
+                        results['precision'][i]}, world.dataset_step[world.dataset])
+            w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "NDCG", world.topks[i]), 
+                    {   str(world.config['svdtype']) + "_" + 
+                        str(world.config['svdvalue']) + "_" + 
+                        str(world.config['filter']) + "_" + 
+                        str(world.config['filter_option']) : 
+                        results['ndcg'][i]}, world.dataset_step[world.dataset])
+            w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Diversity", world.topks[i]), 
+                    {   str(world.config['svdtype']) + "_" + 
+                        str(world.config['svdvalue']) + "_" + 
+                        str(world.config['filter']) + "_" + 
+                        str(world.config['filter_option']) : 
+                        results['diversity'][i]}, world.dataset_step[world.dataset])
+    if multicore == 1:
+        pool.close()
+        pool.join()
+    print(results)
+    end_time = time()
+    print(f"time consumption: {end_time-start_time}s")
+
+def Test_exp3(dataset, epoch, w=None, multicore=0):
+    u_batch_size = world.config['test_u_batch_size']
+    dataset: utils.BasicDataset
+    testDict: dict = dataset.testDict
+    adj_mat = dataset.UserItemNet.tolil()
+    if world.simple_model != 'exp3':
+        raise NotImplementedError
+    
+    lm = model.EXP3(adj_mat)
+    lm.train()
+
+    # eval mode with no dropout
+    max_K = max(world.topks)
+    # Current Problem: Only use Multiprocessing at concating all results, not procedure part
+    # So need to change this part
+    if multicore == 1:
+        pool = multiprocessing.Pool(CORES)
+    #     c_proc = multiprocessing.current_process()
+    # print(f"Core: {CORES} current process: {c_proc.name} and PID:{c_proc.pid}")
+    if abs(world.config['alpha_start']-world.config['alpha_end']) < 1e-8:
+        range_alpha = [world.config['alpha_start']]
+    else:            
+        range_alpha = np.arange(world.config['alpha_start'], world.config['alpha_end'] + 1e-8, world.config['alpha_step'])
+        range_alpha = [round(i, 10) for i in range_alpha]
+
+    if world.config['expdevice'][:4] != 'cpu':
+        adj_mat = convert_sp_mat_to_sp_tensor(adj_mat).to_dense()
+
+    for alpha in range_alpha:
+        start_time = time()
+        results = {'precision': np.zeros(len(world.topks)),
+                'recall': np.zeros(len(world.topks)),
+                'ndcg': np.zeros(len(world.topks)),
+                'diversity': [[] for _ in range(len(world.topks))]}
         
         users = list(testDict.keys())
         try:
@@ -270,18 +561,45 @@ def Test_exp1(dataset, epoch, w=None, multicore=0):
             results['recall'] += result['recall']
             results['precision'] += result['precision']
             results['ndcg'] += result['ndcg']
+            for i in range(len(world.topks)):
+                results['diversity'][i] += result['diversity'][i]
         results['recall'] /= float(len(users))
         results['precision'] /= float(len(users))
         results['ndcg'] /= float(len(users))
-        results['diversity'] = utils.get_diversity(dataset.m_items, rating_list)
+        for i in range(len(world.topks)):
+            results['diversity'][i] = len(list(set(results['diversity'][i]))) / dataset.m_items
+        results['diversity'] = np.array(results['diversity'])
         # results['auc'] = np.mean(auc_record)
         if world.tensorboard:
-            w.add_scalars(f'Test/Recall@{world.topks}',
-                        {str(world.topks[i]): results['recall'][i] for i in range(len(world.topks))}, epoch)
-            w.add_scalars(f'Test/Precision@{world.topks}',
-                        {str(world.topks[i]): results['precision'][i] for i in range(len(world.topks))}, epoch)
-            w.add_scalars(f'Test/NDCG@{world.topks}',
-                        {str(world.topks[i]): results['ndcg'][i] for i in range(len(world.topks))}, epoch)
+            for i in range(len(world.topks)):
+                w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Recall", world.topks[i]), 
+                        {   str(world.config['svdtype']) + "_" + 
+                            str(world.config['svdvalue']) + "_" + 
+                            str(world.config['filter']) + "_" + 
+                            str(world.config['filter_option']) + "_" +
+                            str(alpha) : 
+                            results['recall'][i]}, world.dataset_step[world.dataset])
+                w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Precision", world.topks[i]), 
+                        {   str(world.config['svdtype']) + "_" + 
+                            str(world.config['svdvalue']) + "_" + 
+                            str(world.config['filter']) + "_" + 
+                            str(world.config['filter_option']) + "_" +
+                            str(alpha) : 
+                            results['precision'][i]}, world.dataset_step[world.dataset])
+                w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "NDCG", world.topks[i]), 
+                        {   str(world.config['svdtype']) + "_" + 
+                            str(world.config['svdvalue']) + "_" + 
+                            str(world.config['filter']) + "_" + 
+                            str(world.config['filter_option']) + "_" +
+                            str(alpha) : 
+                            results['ndcg'][i]}, world.dataset_step[world.dataset])
+                w.add_scalars(tensorboard_folder_name(world.simple_model, world.dataset, "Diversity", world.topks[i]), 
+                        {   str(world.config['svdtype']) + "_" + 
+                            str(world.config['svdvalue']) + "_" + 
+                            str(world.config['filter']) + "_" + 
+                            str(world.config['filter_option']) + "_" +
+                            str(alpha) : 
+                            results['diversity'][i]}, world.dataset_step[world.dataset])
         if multicore == 1:
             pool.close()
             pool.join()
@@ -289,109 +607,6 @@ def Test_exp1(dataset, epoch, w=None, multicore=0):
         print(results)
         end_time = time()
         print(f"time consumption: {end_time-start_time}s")
-
-
-def Test_exp2(dataset, epoch, w=None, multicore=0):
-    u_batch_size = world.config['test_u_batch_size']
-    dataset: utils.BasicDataset
-    testDict: dict = dataset.testDict
-    adj_mat = dataset.UserItemNet.tolil()
-    if world.simple_model != 'exp2':
-        raise NotImplementedError
-    
-    lm = model.EXP2(adj_mat)
-    lm.train()
-
-    # eval mode with no dropout
-    max_K = max(world.topks)
-    # Current Problem: Only use Multiprocessing at concating all results, not procedure part
-    # So need to change this part
-    if multicore == 1:
-        pool = multiprocessing.Pool(CORES)
-    #     c_proc = multiprocessing.current_process()
-    # print(f"Core: {CORES} current process: {c_proc.name} and PID:{c_proc.pid}")
-
-    if world.config['expdevice'][:4] != 'cpu':
-        adj_mat = convert_sp_mat_to_sp_tensor(adj_mat).to_dense()
-
-    start_time = time()
-    results = {'precision': np.zeros(len(world.topks)),
-            'recall': np.zeros(len(world.topks)),
-            'ndcg': np.zeros(len(world.topks)),
-            'diversity': 0}
-    users = list(testDict.keys())
-    try:
-        assert u_batch_size <= len(users) / 10
-    except AssertionError:
-        print(f"test_u_batch_size is too big for this dataset, try a small one {len(users) // 10}")
-    users_list = []
-    rating_list = []
-    groundTrue_list = []
-    # auc_record = []
-    # ratings = []
-    total_batch = len(users) // u_batch_size + 1
-
-    for batch_users in utils.minibatch(users, batch_size=u_batch_size):
-        allPos = dataset.getUserPosItems(batch_users)
-        groundTrue = [testDict[u] for u in batch_users]
-        if world.config['expdevice'][:4] != 'cpu':
-            batch_ratings = adj_mat[batch_users, :].to(world.config['expdevice'])
-            rating = lm.getUsersRating(batch_ratings=batch_ratings, batch_users=batch_users)
-        else:
-            rating = lm.getUsersRating(batch_users=batch_users)
-            rating = torch.from_numpy(rating)
-        # rating = rating.to(world.device)
-
-        #rating = rating.cpu()
-        exclude_index = []
-        exclude_items = []
-        for range_i, items in enumerate(allPos):
-            exclude_index.extend([range_i] * len(items))
-            exclude_items.extend(items)
-        rating[exclude_index, exclude_items] = -(1<<10)
-        _, rating_K = torch.topk(rating, k=max_K)
-        rating = rating.cpu().numpy()
-        # aucs = [ 
-        #         utils.AUC(rating[i],
-        #                   dataset, 
-        #                   test_data) for i, test_data in enumerate(groundTrue)
-        #     ]
-        # auc_record.extend(aucs)
-        del rating
-        users_list.append(batch_users)
-        rating_list.append(rating_K.cpu())
-        groundTrue_list.append(groundTrue)
-    assert total_batch == len(users_list)
-    X = zip(rating_list, groundTrue_list)
-    if multicore == 1:
-        pre_results = pool.map(test_one_batch, X)
-    else:
-        pre_results = []
-        for x in X:
-            pre_results.append(test_one_batch(x))
-    scale = float(u_batch_size/len(users))
-    for result in pre_results:
-        results['recall'] += result['recall']
-        results['precision'] += result['precision']
-        results['ndcg'] += result['ndcg']
-    results['recall'] /= float(len(users))
-    results['precision'] /= float(len(users))
-    results['ndcg'] /= float(len(users))
-    results['diversity'] = utils.get_diversity(dataset.m_items, rating_list)
-    # results['auc'] = np.mean(auc_record)
-    if world.tensorboard:
-        w.add_scalars(f'Test/Recall@{world.topks}',
-                    {str(world.topks[i]): results['recall'][i] for i in range(len(world.topks))}, epoch)
-        w.add_scalars(f'Test/Precision@{world.topks}',
-                    {str(world.topks[i]): results['precision'][i] for i in range(len(world.topks))}, epoch)
-        w.add_scalars(f'Test/NDCG@{world.topks}',
-                    {str(world.topks[i]): results['ndcg'][i] for i in range(len(world.topks))}, epoch)
-    if multicore == 1:
-        pool.close()
-        pool.join()
-    print(results)
-    end_time = time()
-    print(f"time consumption: {end_time-start_time}s")
 
 # from BSPM: https://github.com/jeongwhanchoi/BSPM/Procedure.py
 def convert_sp_mat_to_sp_tensor(X) -> torch.sparse.FloatTensor: 

--- a/sojong-exp/filter.py
+++ b/sojong-exp/filter.py
@@ -1,0 +1,69 @@
+import numpy as np
+import math
+
+class Filter(object):
+    def __init__(self, option) -> None:
+        pass
+class LinearFilter(Filter):
+    def __init__(self, option) -> None:
+        super(LinearFilter, self).__init__(option)
+    def __call__(self, s: np.array) -> np.array:
+        return s
+class IdealLowPassFilter(Filter):
+    def __init__(self, option) -> None:
+        super(IdealLowPassFilter, self).__init__(option)
+    def __call__(self, s: np.array) -> np.array:
+        return np.ones(shape=s.shape, dtype=float)
+class GaussianFilter(Filter):
+    def __init__(self, alpha=0.2) -> None:
+        super(GaussianFilter, self).__init__(alpha)
+        if alpha < 0:
+            self.alpha = 0.2
+        else:
+            self.alpha = alpha
+    def __call__(self, s: np.array) -> np.array:
+        return np.exp(-self.alpha * (s**2))
+class HeatKernelFilter(Filter):
+    def __init__(self, alpha=0.1) -> None:
+        super(HeatKernelFilter, self).__init__(alpha)
+        if alpha < 0:
+            self.alpha = 0.1
+        else:
+            self.alpha = alpha
+    def __call__(self, s: np.array) -> np.array:
+        return np.exp(-self.alpha * s)
+class ButterWorthFilter(Filter):
+    def __init__(self, order=1) -> None:
+        super(ButterWorthFilter, self).__init__(order)
+        self.order = order
+        self.order_list = [1,2,3]
+        if self.order == 1:
+            self.butterworth = lambda s: 1 / (s + 1)
+        elif self.order == 2:
+            self.butterworth = lambda s: 1 / (s**2 + math.sqrt(2)*s + 1)
+        elif self.order == 3:
+            self.butterworth = lambda s: 1 / ((s+1) * (s**2 + s + 1))
+        else:
+            print("We only use filter order value in [1, 2, 3]")
+            raise NotImplementedError
+    def __call__(self, s: np.array) -> np.array:
+        return self.butterworth(s)
+class GFCFLinearAutoencoderFilter(Filter):
+    def __init__(self, mu=0.1) -> None:
+        super(GFCFLinearAutoencoderFilter, self).__init__(mu)
+        if mu < 0:
+            self.mu = 0.1
+        else:
+            self.mu = mu
+    def __call__(self, s: np.array) -> np.array:
+        return (1 - s) / (1 - s + self.mu)
+class GFCFNeighborhoodBasedFilter(Filter):
+    def __init__(self, option) -> None:
+        super(GFCFNeighborhoodBasedFilter, self).__init__(option)
+    def __call__(self, s: np.array) -> np.array:
+        return (1 - s)
+class InverseFilter(Filter):
+    def __init__(self, option) -> None:
+        super(InverseFilter, self).__init__(option)
+    def __call__(self, s: np.array) -> np.array:
+        return 1/s

--- a/sojong-exp/filter.py
+++ b/sojong-exp/filter.py
@@ -2,40 +2,34 @@ import numpy as np
 import math
 
 class Filter(object):
-    def __init__(self, option) -> None:
+    def __init__(self) -> None:
         pass
 class LinearFilter(Filter):
-    def __init__(self, option) -> None:
-        super(LinearFilter, self).__init__(option)
+    def __init__(self) -> None:
+        super(LinearFilter, self).__init__()
     def __call__(self, s: np.array) -> np.array:
         return s
 class IdealLowPassFilter(Filter):
-    def __init__(self, option) -> None:
-        super(IdealLowPassFilter, self).__init__(option)
+    def __init__(self) -> None:
+        super(IdealLowPassFilter, self).__init__()
     def __call__(self, s: np.array) -> np.array:
         return np.ones(shape=s.shape, dtype=float)
 class GaussianFilter(Filter):
-    def __init__(self, alpha=0.2) -> None:
-        super(GaussianFilter, self).__init__(alpha)
-        if alpha < 0:
-            self.alpha = 0.2
-        else:
-            self.alpha = alpha
+    def __init__(self, *nargs) -> None:
+        super(GaussianFilter, self).__init__()
+        self.alpha = 0.2 if len(nargs) == 0 else nargs[0]
     def __call__(self, s: np.array) -> np.array:
         return np.exp(-self.alpha * (s**2))
 class HeatKernelFilter(Filter):
-    def __init__(self, alpha=0.1) -> None:
-        super(HeatKernelFilter, self).__init__(alpha)
-        if alpha < 0:
-            self.alpha = 0.1
-        else:
-            self.alpha = alpha
+    def __init__(self, *nargs) -> None:
+        super(HeatKernelFilter, self).__init__()
+        self.alpha = 0.1 if len(nargs) == 0 else nargs[0]
     def __call__(self, s: np.array) -> np.array:
         return np.exp(-self.alpha * s)
 class ButterWorthFilter(Filter):
-    def __init__(self, order=1) -> None:
-        super(ButterWorthFilter, self).__init__(order)
-        self.order = order
+    def __init__(self, *nargs) -> None:
+        super(ButterWorthFilter, self).__init__()
+        self.order = 1 if len(nargs)==0 else nargs[0]
         self.order_list = [1,2,3]
         if self.order == 1:
             self.butterworth = lambda s: 1 / (s + 1)
@@ -49,21 +43,18 @@ class ButterWorthFilter(Filter):
     def __call__(self, s: np.array) -> np.array:
         return self.butterworth(s)
 class GFCFLinearAutoencoderFilter(Filter):
-    def __init__(self, mu=0.1) -> None:
-        super(GFCFLinearAutoencoderFilter, self).__init__(mu)
-        if mu < 0:
-            self.mu = 0.1
-        else:
-            self.mu = mu
+    def __init__(self, *nargs) -> None:
+        super(GFCFLinearAutoencoderFilter, self).__init__()
+        self.mu = 0.1 if len(nargs)==0 else nargs[0]
     def __call__(self, s: np.array) -> np.array:
         return (1 - s) / (1 - s + self.mu)
 class GFCFNeighborhoodBasedFilter(Filter):
-    def __init__(self, option) -> None:
-        super(GFCFNeighborhoodBasedFilter, self).__init__(option)
+    def __init__(self) -> None:
+        super(GFCFNeighborhoodBasedFilter, self).__init__()
     def __call__(self, s: np.array) -> np.array:
         return (1 - s)
 class InverseFilter(Filter):
-    def __init__(self, option) -> None:
-        super(InverseFilter, self).__init__(option)
+    def __init__(self) -> None:
+        super(InverseFilter, self).__init__()
     def __call__(self, s: np.array) -> np.array:
         return 1/s

--- a/sojong-exp/main.py
+++ b/sojong-exp/main.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
 
     weight_file = utils.getFileName()
     print(f"load and save to {weight_file}")
-    if world.LOAD:
+    if world.LOAD and world.simple_model[:3] != "exp":
         try:
             Recmodel.load_state_dict(torch.load(weight_file,map_location=torch.device('cpu')))
             world.cprint(f"loaded model weights from {weight_file}")
@@ -37,10 +37,14 @@ if __name__ == '__main__':
     Neg_k = 1
 
     # init tensorboard
-    if world.tensorboard:
+    if world.tensorboard and world.simple_model[:3] != "exp":
         w : SummaryWriter = SummaryWriter(
                                         join(world.BOARD_PATH, time.strftime("%m-%d-%Hh%Mm%Ss-") + "-" + world.comment)
                                         )
+    elif world.tensorboard and world.simple_model[:3] == 'exp':
+        w : SummaryWriter = SummaryWriter(
+                                        join(world.BOARD_PATH, world.simple_model + "-" + world.dataset)
+        )
     else:
         w = None
         world.cprint("not enable tensorflowboard")
@@ -58,6 +62,14 @@ if __name__ == '__main__':
             cprint("[TEST]")
             start_time = time.time()
             Procedure.Test_exp2(dataset, epoch, w, world.config['multicore'])
+            end_time = time.time()
+            print(f"total time consumption: {end_time-start_time}s")
+        elif world.simple_model == 'exp3':
+            epoch = 0
+            cprint("[TEST]")
+            start_time = time.time()
+            # create tensorboard inside of procedure funtion
+            Procedure.Test_exp3(dataset, epoch, w, world.config['multicore'])
             end_time = time.time()
             print(f"total time consumption: {end_time-start_time}s")
         elif(world.simple_model != 'none'):

--- a/sojong-exp/model.py
+++ b/sojong-exp/model.py
@@ -387,7 +387,7 @@ class EXPS(object):
 
         if world.config['expdevice'][:4] == 'cuda':
             # # let's check if we don't use large linear filter, just multiply with diagonal matrices!
-            if world.config['filter'][0] == 'linear' or type(self) is not EXP2:
+            if type(self) is not EXP2 or world.config['filter'][0] == 'linear':
                 if world.dataset == 'amazon-book':
                     print('Amazon dataset is not Suitable for Commercial GPU - need 48GB of VRAM')
                     print('Use Sparse Matrix Multiplication of CUDA')

--- a/sojong-exp/model.py
+++ b/sojong-exp/model.py
@@ -433,7 +433,7 @@ class EXP1(EXPS):
             batch_test = np.array(adj_mat[batch_users,:].todense())
             U_2 = batch_test @ self.norm_adj.T @ self.norm_adj
             U_1 = batch_test @ self.d_mat_i @ self.vt.T @ self.vt @ self.d_mat_i_inv
-            ret = U_2 + alpha * U_1
+            return alpha * U_1 + U_2
             return ret
         else:
             batch_test = batch_ratings.to_sparse()
@@ -533,7 +533,7 @@ class EXP3(EXPS):
             batch_test = np.array(adj_mat[batch_users,:].todense())
             U_2 = batch_test @ self.norm_adj.T @ self.norm_adj
             U_1 = batch_test @ self.d_mat_i @ self.vt.T @ np.diag(self.s_filter) @ self.vt @ self.d_mat_i_inv
-            return U_2 + alpha * U_1
+            return alpha * U_1 + U_2
         else:
             batch_test = batch_ratings.to_sparse()
             if world.dataset != 'amazon-book':
@@ -542,4 +542,4 @@ class EXP3(EXPS):
                 U_2 = batch_test @ self.norm_adj_cuda_sparse.T @ self.norm_adj_cuda_sparse
                 # U_2 = batch_test @ self.linear_Filter_cuda_sparse
             U_1 = batch_test @ self.left_mat_cuda @ torch.diag(self.s_filter_cuda) @ self.right_mat_cuda
-            return U_2 + alpha * U_1
+            return alpha * U_1 + U_2

--- a/sojong-exp/parse.py
+++ b/sojong-exp/parse.py
@@ -59,6 +59,6 @@ def parse_args():
     # for exp2
     # parser.add_argument('--filter', type=str, default='ideal-low-pass', help='linear, ideal-low-pass, gaussian, heat-kernel, butterworth, gfcf-linear-autoencoder, gfcf-Neighborhood-based')
     # parser.add_argument('--filter_option', type=str, default=-1, help='gaussian(alpha), heat-kernel(alpha), butterworth filter(1,2,3), gfcf-linear-autoencoder(mu)')
-    parser.add_argument('--filter', nargs='?', help='[filter_name, option] - [linear], [ideal-low-pass], [gaussian, mu], [heat-kernel, alpha], [butterworth, 1|2|3], [gfcf-linear-autoencoder, mu], [gfcf-Neighborhood-based, ]')
+    parser.add_argument('--filter', nargs='?', default='[]', help='[filter_name, option] - [linear], [ideal-low-pass], [gaussian, mu], [heat-kernel, alpha], [butterworth, 1|2|3], [gfcf-linear-autoencoder, mu], [gfcf-Neighborhood-based, ]')
 
     return parser.parse_args()

--- a/sojong-exp/parse.py
+++ b/sojong-exp/parse.py
@@ -59,6 +59,6 @@ def parse_args():
     # for exp2
     # parser.add_argument('--filter', type=str, default='ideal-low-pass', help='linear, ideal-low-pass, gaussian, heat-kernel, butterworth, gfcf-linear-autoencoder, gfcf-Neighborhood-based')
     # parser.add_argument('--filter_option', type=str, default=-1, help='gaussian(alpha), heat-kernel(alpha), butterworth filter(1,2,3), gfcf-linear-autoencoder(mu)')
-    parser.add_argument('--filter', nargs='?', default='[]', help='[filter_name, option] - [linear], [ideal-low-pass], [gaussian, mu], [heat-kernel, alpha], [butterworth, 1|2|3], [gfcf-linear-autoencoder, mu], [gfcf-Neighborhood-based, ]')
+    parser.add_argument('--filter', nargs='?', default="['ideal-low-pass']", help='[filter_name, option] - [linear], [ideal-low-pass], [gaussian, mu], [heat-kernel, alpha], [butterworth, 1|2|3], [gfcf-linear-autoencoder, mu], [gfcf-Neighborhood-based, ]')
 
     return parser.parse_args()

--- a/sojong-exp/parse.py
+++ b/sojong-exp/parse.py
@@ -57,7 +57,8 @@ def parse_args():
     parser.add_argument('--alpha_end', type=float, default=0.3, help='0~1 float value')
     parser.add_argument('--alpha_step', type=float, default=0.05, help='step of alpha values')
     # for exp2
-    parser.add_argument('--filter', type=str, default='ideal-low-pass', help='linear, ideal-low-pass, gaussian, heat-kernel, butterworth, gfcf-linear-autoencoder, gfcf-Neighborhood-based')
-    parser.add_argument('--filter_option', type=str, default=-1, help='gaussian(alpha), heat-kernel(alpha), butterworth filter(1,2,3), gfcf-linear-autoencoder(mu)')
+    # parser.add_argument('--filter', type=str, default='ideal-low-pass', help='linear, ideal-low-pass, gaussian, heat-kernel, butterworth, gfcf-linear-autoencoder, gfcf-Neighborhood-based')
+    # parser.add_argument('--filter_option', type=str, default=-1, help='gaussian(alpha), heat-kernel(alpha), butterworth filter(1,2,3), gfcf-linear-autoencoder(mu)')
+    parser.add_argument('--filter', nargs='?', help='[filter_name, option] - [linear], [ideal-low-pass], [gaussian, mu], [heat-kernel, alpha], [butterworth, 1|2|3], [gfcf-linear-autoencoder, mu], [gfcf-Neighborhood-based, ]')
 
     return parser.parse_args()

--- a/sojong-exp/parse.py
+++ b/sojong-exp/parse.py
@@ -57,7 +57,7 @@ def parse_args():
     parser.add_argument('--alpha_end', type=float, default=0.3, help='0~1 float value')
     parser.add_argument('--alpha_step', type=float, default=0.05, help='step of alpha values')
     # for exp2
-    parser.add_argument('--filter', type=str, default='linear', help='linear, ideal-low-pass, gaussian, heat-kernel, butterworth, gfcf-linear-autoencoder, gfcf-Neighborhood-based')
+    parser.add_argument('--filter', type=str, default='ideal-low-pass', help='linear, ideal-low-pass, gaussian, heat-kernel, butterworth, gfcf-linear-autoencoder, gfcf-Neighborhood-based')
     parser.add_argument('--filter_option', type=str, default=-1, help='gaussian(alpha), heat-kernel(alpha), butterworth filter(1,2,3), gfcf-linear-autoencoder(mu)')
 
     return parser.parse_args()

--- a/sojong-exp/world.py
+++ b/sojong-exp/world.py
@@ -56,8 +56,10 @@ config['alpha_start'] = args.alpha_start
 config['alpha_end'] = args.alpha_end
 config['alpha_step'] = args.alpha_step
 # for exp2
-config['filter'] = args.filter
-config['filter_option'] = args.filter_option
+# config['filter'] = args.filter
+# config['filter_option'] = args.filter_option
+config['filter'] = eval(args.filter)
+filter_list = ['linear', 'ideal-low-pass', 'gaussian', 'heat-kernel', 'butterworth', 'gfcf-linear-autoencoder', 'gfcf-Neighborhood-based', 'inverse']
 
 GPU = torch.cuda.is_available()
 device = torch.device('cuda' if GPU else "cpu")

--- a/sojong-exp/world.py
+++ b/sojong-exp/world.py
@@ -26,6 +26,11 @@ if not os.path.exists(FILE_PATH):
 
 config = {}
 all_dataset = ['lastfm', 'gowalla', 'yelp2018', 'amazon-book']
+dataset_step = {'amazon-book': 0,
+                'gowalla': 1,
+                'yelp2018': 2,
+                'lastfm': 3
+                }
 all_models  = ['mf', 'lgn']
 # config['batch_size'] = 4096
 config['bpr_batch_size'] = args.bpr_batch


### PR DESCRIPTION
## 여러 구조를 바꿈. 최대한 자세하게 적어볼게

### PR 생성일시
* 2023/05/10

### PR 내용
- cupyx 추가 : scipy를 cuda로 돌리는 library인데, scipy에 존재하는, svd에서 eigenvalue 작은걸 뽑는 부분이 구현이 안되어있음. 그래서 해당 모듈은 없어도 정상 작동되도록 exception 처리 해둠
- tensorboard에 결과 출력되도록 변경
- diversity가 여러 topks에 대해 적용되지 않던 것을 수정.
- filter를 model.py에서 분리: filter 생성해서 업로드 하기 편하게 하기 위해서
- parser에서 받는 인자 구조 변경.

### PR 유의사항
> EXP1 실행 방법
- sojong-exp 폴더로 이동 후 다음 명령어 수행
- `python main.py --dataset="amazon-book" --topks="[20]" --simple_model="exp1" --expdevice="cuda:0" --svdvalue=256 --svdtype="torch_cuda" --alpha_start=0.0 --alpha_end=0.1 --alpha_step=0.05`
- --dataset: 'amazon-book', 'gowalla', 'yelp2018'
- --topks: top k를 list형태로 문자열 넣기, '[10,20]' 이렇게 list를 string으로 바꿔서
- --simple_model: exp1을 하려면 무조건 exp1로 고정
- --expdevice: gpu 있으면 cuda 번호까지, 아니면 'cpu'
- --svdvalue: svd dimension
- --svdtype: 기본은 'sparsesvd', 다른 옵션들로는 'scipy', 'sklearn-rand', 'fbpca', 'torch', 'torch_cuda', 'cupy'가 있다. torch_cuda와 cupy는 cuda가 있어야 가능.
- --alpha_start: 시직 alpha값. 음수도 가능
- --alpha_end: 끝낼 alpha 값. 음수도 가능. 
- --alpha_step: 다음 alpha값을 어떻게 바꿀지. 음수도 가능함.
- -- 하나의 alpha로 실험할 경우, alpha_start와 alpha_end를 동일하게 하면 됨.
> EXP2 실행 방법
- sojong-exp 폴더로 이동 후 다음 명령어 수행
- `python main.py --dataset="amazon-book" --topks="[20]" --simple_model="exp2" --expdevice="cuda:0" --svdvalue=256 --svdtype="torch_cuda" --filter="['ideal-low-pass']"`
- --filter 앞의 옵션은 전부 동일
- --filter="[  {filter 이름 string}, {filter option값} ]" 의 형태로, list를 string으로 적은 형태로 넣어야함
- -- 해당 argument의 첫 번째 element는 filter 이름, 두 번째는 해당 filter가 필요한 option을 숫자(string 아님!)으로 넣으면 된다.
- -- 기본 값은 "['ideal-low-pass']"이다.
> EXP3 실행 방법
- sojong-exp 폴더로 이동 후 다음 명령어 수행
- `python main.py --dataset="amazon-book" --topks="[20]" --simple_model="exp3" --expdevice="cuda:0" --svdvalue=256 --svdtype="torch_cuda" --alpha_start=0.0 --alpha_end=0.0 --alpha_step=0.05 --filter="['ideal-low-pass']"`
- EXP1과 EXP2를 합친 모양